### PR TITLE
17 change log level in alanubeapiprocess response to debug

### DIFF
--- a/alanube/do/api.py
+++ b/alanube/do/api.py
@@ -140,6 +140,8 @@ class AlanubeAPI:
 
     @staticmethod
     def get_headers():
+        if AlanubeAPI.config is None:
+            raise RuntimeError("API not connected. Call AlanubeAPI.connect first.")
         return {
             "Authorization": f"Bearer {AlanubeAPI.config.token}",
             "Content-Type": "application/json",

--- a/alanube/do/api.py
+++ b/alanube/do/api.py
@@ -149,7 +149,9 @@ class AlanubeAPI:
     @staticmethod
     def request(endpoint, method='GET', params=None, data=None, expected_response_code=None):
         headers = AlanubeAPI.get_headers()
-        logger.info(f"{method}: {endpoint} | Params: {params} | Data: {data}")
+        logger.info(f"{method}: {endpoint} | Params: {params}")
+        if data:
+            logger.debug(f"Data: {data}")
         response = requests.request(method, endpoint, headers=headers, params=params, json=data)
         return response
 
@@ -189,11 +191,12 @@ class AlanubeAPI:
     @staticmethod
     def process_response(response: requests.Response, expected_response_code: int = None):
         handle_response_error(response, expected_response_code=expected_response_code)
+        logger.info(f"Response: {response.status_code}")
         try:
-            logger.info(f"Response: {response.status_code} | json: {response.json()}")
+            logger.debug(f"JSON: {response.json()}")
         except ValueError:
             logger.error("Error parsing response as JSON")
-            logger.info(f"Response: {response.status_code} | text: {response.text}")
+            logger.debug(f"Text: {response.text}")
         return response
 
     @classmethod

--- a/alanube/do/config.py
+++ b/alanube/do/config.py
@@ -58,7 +58,7 @@ CURRENCIES = dict(
     CHY='CHY',  # YUAN CHINO
     XDR='XDR',  # DERECHO ESPECIAL DE GIRO83
     DKK='DKK',  # CORONA DANESA
-    ERU='EUR',  # EURO
+    EUR='EUR',  # EURO
     GBP='GBP',  # LIBRA ESTERLINA
     JPY='JPY',  # YEN JAPONES
     NOK='NOK',  # CORONA NORUEGA
@@ -66,6 +66,8 @@ CURRENCIES = dict(
     SEK='SEK',  # CORONA SUECA
     USD='USD',  # DOLAR ESTADOUNIDENSE
     VEF='VEF',  # BOLIVAR FUERTE VENEZOLANO
+    HTG='HTG',  # GURDA HAITIANA
+    MXN='MXN',  # PESO MEXICANO
 )
 
 
@@ -125,5 +127,11 @@ UNIT_MEASURES = {
     53: {'Abrev.': 'P2', 'Medida': 'Pie cuadrado'},
     54: {'Abrev.': 'PAX', 'Medida': 'Pasajero'},
     55: {'Abrev.': 'PULG', 'Medida': 'Pulgadas'},
-    56: {'Abrev.': 'STAY', 'Medida': 'Parqueo barcos en muelle'}
+    56: {'Abrev.': 'STAY', 'Medida': 'Parqueo barcos en muelle'},
+    57: {'Abrev.': 'BDJ', 'Medida': 'Bandeja'},
+    58: {'Abrev.': 'HA', 'Medida': 'Hectárea'},
+    59: {'Abrev.': 'ML', 'Medida': 'Mililitro'},
+    60: {'Abrev.': 'MG', 'Medida': 'Miligramo'},
+    61: {'Abrev.': 'OZ', 'Medida': 'Onzas'},
+    62: {'Abrev.': 'OZT', 'Medida': 'Onzas Troy'},
 }

--- a/alanube/do/config.py
+++ b/alanube/do/config.py
@@ -42,12 +42,12 @@ TO_NOTIFY = "TO_NOTIFY"
 FINISHED = "FINISHED"
 
 ALANUBE_RESPONSE_STATUS_CHOICES = (
-    (REGISTERED, "Se registró el documento"),
-    (TO_SEND, "Se registró y está listo para ser enviado"),
-    (FAILED, "Falló el envío, normalmente porque se está enviando un eNFC que ya se envió"),
-    (WAITING_RESPONSE, "Fue enviado y se encuentra en espera de respuesta de la DGII"),
-    (TO_NOTIFY, "Obtuvo respuesta de la DGII y se notificará mediante el webhook registrado"),
-    (FINISHED, "Su proceso ha finalizado"),
+    (REGISTERED, "Registered"),              # Se registró el documento
+    (TO_SEND, "To send"),                    # Se registró y está listo para ser enviado
+    (FAILED, "Failed"),                      # Falló el envío, normalmente porque se está enviando un eNFC que ya se envió
+    (WAITING_RESPONSE, "Waiting response"),  # Fue enviado y se encuentra en espera de respuesta de la DGII
+    (TO_NOTIFY, "To notify"),                # Obtuvo respuesta de la DGII y se notificará mediante el webhook registrado
+    (FINISHED, "Finished"),                  # Su proceso ha finalizado
 )
 
 


### PR DESCRIPTION
This pull request introduces several updates to the `alanube/do/api.py` and `alanube/do/config.py` files, focusing on improving error handling, logging, and internationalization, as well as expanding configuration options for currencies and measurement units. Below is a summary of the most important changes:

### Error Handling and Logging Improvements:
* Added a runtime check in `alanube/do/api.py` to ensure the API is connected before retrieving headers, raising an error if not connected.
* Enhanced logging in `alanube/do/api.py` by separating `data` and `response` details into `logger.debug` calls for better granularity. [[1]](diffhunk://#diff-503feaef06bd764083198ea69bcf7b9fdd2f528c78dfa48743710c980a33d992L152-R156) [[2]](diffhunk://#diff-503feaef06bd764083198ea69bcf7b9fdd2f528c78dfa48743710c980a33d992R196-R201)

### Internationalization Updates:
* Updated status descriptions in `alanube/do/config.py` to English while retaining Spanish comments for context.

### Configuration Enhancements:
* Fixed a typo in the currency configuration (`ERU` changed to `EUR`) and added new currencies: Haitian Gourde (`HTG`) and Mexican Peso (`MXN`).
* Expanded the measurement unit configuration in `alanube/do/config.py` by adding new units such as `Bandeja`, `Hectárea`, `Mililitro`, `Miligramo`, `Onzas`, and `Onzas Troy`.