### PR TITLE
feat(do): add unified APIErrorItem parsing with backward compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.languageServer": "None"
+}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ Now you can easily and efficiently use the Alanube API with this Python library!
 | `get_report_company_accepted_documents_monthly` | Monthly totals of accepted documents (12 months). |
 | `get_report_company_accepted_documents_15_days` | Daily totals of accepted documents (last 15 days). |
 
+### Error Handling
+
+Since v1.3.0, API errors are parsed into structured `APIErrorItem` objects:
+
+```python
+from alanube.do.exceptions import APIErrorItem, ValidationError
+
+try:
+    company = AlanubeAPI.create_company({...})
+except ValidationError as e:
+    for error in e.error_items:
+        print(f"[{error.code}] {error.message} (field: {error.field})")
+```
+
+Supported error formats:
+- **Unified format**: `{"code": 400, "errors": [{"code": "...", "message": "...", "field": "..."}]}`
+- **Legacy formats**: `{"message": [...]}`, `{"errors": [...]}`, etc.
+
+Legacy formats continue to work without changes.
+
 ## Contents
 
 - `do`: Fully implemented for the Dominican Republic (DGII).

--- a/alanube/__init__.py
+++ b/alanube/__init__.py
@@ -15,6 +15,6 @@ Country-specific directories:
 - `bo`: Implementation for Bolivia (future)
 """
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __author__ = "Wilmer Martínez"
 __license__ = "MIT"

--- a/alanube/do/exceptions.py
+++ b/alanube/do/exceptions.py
@@ -1,8 +1,95 @@
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, List, Optional
 import requests
 
 
 NON_FIELD_ERRORS = "non_field_errors"
+
+
+@dataclass
+class APIErrorItem:
+    """
+    This represents an individual error in the new unified API format.
+
+    Attributes:
+        `code`: Unique identifier for the error (e.g., "INVALID_FIELD").
+        `message`: Diagnostic description of the error in English.
+        `field`: Field associated with the error, when applicable. Can be None.
+    """
+    code: str
+    message: str
+    field: Optional[str] = None
+
+
+def _parse_error_response(errors: Any) -> List[APIErrorItem]:
+    """
+    Parses the API error response and returns a list of APIErrorItems.
+
+    Supports both the new unified format and legacy formats to maintain
+    backward compatibility during the transition.
+
+    New format:
+        ```json
+        { "code": 400, "errors": [ { "code": "...", "message": "...", "field": "..." } ] }
+        ```
+
+    Legacy formats:
+        ```
+        { "code": 400, "message": ["error message"] }
+        { "code": 400, "errors": ["error message"] }
+        { "errors": ["error message"] }
+        ```
+
+    """
+    items: List[APIErrorItem] = []
+
+    if isinstance(errors, dict):
+        # --- New unified format ---
+        raw_errors = errors.get("errors")
+        if isinstance(raw_errors, list):
+            for raw in raw_errors:
+                if isinstance(raw, dict) and "code" in raw and "message" in raw:
+                    items.append(APIErrorItem(
+                        code=str(raw["code"]),
+                        message=str(raw["message"]),
+                        field=str(raw["field"]) if raw.get("field") else None,
+                    ))
+                elif isinstance(raw, str):
+                    # Legacy: errors as a list of strings
+                    items.append(APIErrorItem(
+                        code="UNKNOWN",
+                        message=raw,
+                        field=None,
+                    ))
+            if items:
+                return items
+
+        # --- Legacy formats (dict with "message" or "errors" as a list/string) ---
+        for key in ("message", "errors"):
+            raw = errors.get(key)
+            if isinstance(raw, list):
+                for msg in raw:
+                    if isinstance(msg, str):
+                        items.append(APIErrorItem(code="UNKNOWN", message=msg, field=None))
+                if items:
+                    return items
+            elif isinstance(raw, str):
+                items.append(APIErrorItem(code="UNKNOWN", message=raw, field=None))
+                return items
+
+        # --- Fallback: take the entire dict as a string representation ---
+        items.append(APIErrorItem(code="UNKNOWN", message=str(errors), field=None))
+
+    elif isinstance(errors, list):
+        # Legacy: errors as a flat list of strings
+        for msg in errors:
+            if isinstance(msg, str):
+                items.append(APIErrorItem(code="UNKNOWN", message=msg, field=None))
+
+    if not items:
+        items.append(APIErrorItem(code="UNKNOWN", message=str(errors), field=None))
+
+    return items
 
 
 class AlanubeError(Exception):
@@ -16,7 +103,8 @@ class APIError(AlanubeError):
 
     Attributes:
         message:      explanation of the error
-        errors:       errors returned by the API
+        errors:       list of APIErrorItem parsed from the API response
+        error_items:  alias for errors (list of APIErrorItem)
         response:     the HTTP response object
         status_code:  HTTP status code if available
         url:          request URL if available
@@ -29,14 +117,18 @@ class APIError(AlanubeError):
         response: Optional[requests.Response] = None,
     ):
         self.response = response
-        self.errors = errors or {}
         self.status_code = getattr(response, "status_code", None)
         self.url = getattr(response, "url", None)
 
+        # Parse the errors to the new unified format
+        self.error_items: List[APIErrorItem] = _parse_error_response(errors or {})
+        self.errors: List[APIErrorItem] = self.error_items  # alias for compatibility
+
         if message:
             final_message = message
-        elif self.errors:
-            final_message = self.errors.get("message") or str(self.errors)
+        elif self.error_items:
+            # Use the first available message as the main message
+            final_message = self.error_items[0].message
         elif self.status_code or self.url:
             final_message = f"{self.status_code or 'N/A'}: {self.url or 'unknown url'}"
         else:
@@ -47,8 +139,8 @@ class APIError(AlanubeError):
 
     @property
     def messages(self):
-        """Return a list of error messages."""
-        return [e2 for e1 in self.errors.values() for e2 in (e1 if isinstance(e1, list) else [e1])]
+        """Return a list of error messages from parsed error items."""
+        return [item.message for item in self.error_items]
 
 
 class ObjectDoesNotExist(APIError):

--- a/alanube/tests/test_do.py
+++ b/alanube/tests/test_do.py
@@ -1,9 +1,18 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from alanube.do import Alanube
 from alanube.do.api import APIConfig, AlanubeAPI
-from alanube.do.exceptions import ValidationError
+from alanube.do.exceptions import (
+    APIError,
+    APIErrorItem,
+    NotFound,
+    ValidationError,
+    _parse_error_response,
+    handle_response_error,
+)
 
 
 class TestAlanube(unittest.TestCase):
@@ -180,3 +189,270 @@ class TestAlanubeAPI(unittest.TestCase):
             with self.assertRaises(ValidationError):
                 AlanubeAPI.get_received_documents(limit=0)
             mock_request.assert_not_called()
+
+
+class TestAPIErrorParsing(unittest.TestCase):
+    """Tests para el parseo del nuevo formato unificado de errores de la API."""
+
+    # --- _parse_error_response ---
+
+    def test_new_unified_format(self):
+        """El nuevo formato unificado se parsea correctamente."""
+        error_data = {
+            "code": 400,
+            "errors": [
+                {"code": "INVALID_FIELD", "message": "Invalid field value", "field": "name"},
+                {"code": "REQUIRED", "message": "Field is required", "field": "email"},
+            ]
+        }
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].code, "INVALID_FIELD")
+        self.assertEqual(items[0].message, "Invalid field value")
+        self.assertEqual(items[0].field, "name")
+        self.assertEqual(items[1].code, "REQUIRED")
+        self.assertEqual(items[1].message, "Field is required")
+        self.assertEqual(items[1].field, "email")
+
+    def test_new_format_without_field(self):
+        """El campo 'field' es opcional en el nuevo formato."""
+        error_data = {
+            "code": 500,
+            "errors": [
+                {"code": "INTERNAL_ERROR", "message": "Internal server error"},
+            ]
+        }
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].code, "INTERNAL_ERROR")
+        self.assertEqual(items[0].message, "Internal server error")
+        self.assertIsNone(items[0].field)
+
+    def test_legacy_format_message_list(self):
+        """Formato legacy: { 'code': 400, 'message': ['error msg'] }"""
+        error_data = {"code": 400, "message": ["error message"]}
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].message, "error message")
+        self.assertEqual(items[0].code, "UNKNOWN")
+
+    def test_legacy_format_errors_list(self):
+        """Formato legacy: { 'code': 400, 'errors': ['error msg'] }"""
+        error_data = {"code": 400, "errors": ["error message"]}
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].message, "error message")
+        self.assertEqual(items[0].code, "UNKNOWN")
+
+    def test_legacy_format_errors_only(self):
+        """Formato legacy: { 'errors': ['error message'] }"""
+        error_data = {"errors": ["error message"]}
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].message, "error message")
+
+    def test_legacy_format_plain_string(self):
+        """Formato legacy: { 'message': 'single error string' }"""
+        error_data = {"message": "single error"}
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].message, "single error")
+
+    def test_new_format_takes_precedence_over_legacy(self):
+        """Si están presentes ambos formatos, el nuevo formato tiene prioridad."""
+        error_data = {
+            "code": 400,
+            "errors": [
+                {"code": "VALIDATION", "message": "Validation failed", "field": "amount"},
+            ],
+            "message": ["legacy message"],
+        }
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].code, "VALIDATION")
+        self.assertEqual(items[0].message, "Validation failed")
+
+    def test_empty_errors_list(self):
+        """Lista de errores vacía produce un fallback con str(errors)."""
+        error_data = {"code": 400, "errors": []}
+        items = _parse_error_response(error_data)
+        self.assertEqual(len(items), 1)
+
+    def test_empty_dict(self):
+        """Dict vacío produce un fallback."""
+        items = _parse_error_response({})
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].code, "UNKNOWN")
+
+    def test_plain_list(self):
+        """Lista plana de strings (legacy)."""
+        items = _parse_error_response(["error one", "error two"])
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].message, "error one")
+        self.assertEqual(items[1].message, "error two")
+
+    # --- APIError ---
+
+    def test_api_error_message_from_error_items(self):
+        """APIError usa el primer mensaje de error_items como message."""
+        error_data = {
+            "code": 400,
+            "errors": [{"code": "BAD_REQUEST", "message": "Invalid input", "field": "amount"}]
+        }
+        exc = APIError(errors=error_data)
+        self.assertEqual(exc.message, "Invalid input")
+        self.assertEqual(len(exc.error_items), 1)
+        self.assertEqual(exc.error_items[0].code, "BAD_REQUEST")
+
+    def test_api_error_messages_property(self):
+        """La property messages retorna todos los mensajes del array errors."""
+        error_data = {
+            "code": 400,
+            "errors": [
+                {"code": "E1", "message": "Error one"},
+                {"code": "E2", "message": "Error two"},
+            ]
+        }
+        exc = APIError(errors=error_data)
+        self.assertEqual(exc.messages, ["Error one", "Error two"])
+
+    def test_api_error_errors_alias(self):
+        """errors y error_items son equivalentes y apuntan al mismo objeto."""
+        error_data = {
+            "code": 400,
+            "errors": [{"code": "E1", "message": "Error"}]
+        }
+        exc = APIError(errors=error_data)
+        self.assertIs(exc.errors, exc.error_items)
+
+    def test_api_error_message_explicit_overrides(self):
+        """Si se pasa un message explícito, se usa en lugar del de error_items."""
+        exc = APIError(message="Custom error message")
+        self.assertEqual(exc.message, "Custom error message")
+        self.assertIsInstance(exc.error_items, list)
+
+    def test_api_error_errors_none_no_response(self):
+        """Si errors es None y no hay response, no falla."""
+        exc = APIError()
+        self.assertIsInstance(exc.error_items, list)
+        self.assertIsNone(exc.status_code)
+        self.assertIsNone(exc.url)
+
+    def test_api_error_status_code_and_url_from_response(self):
+        """status_code y url se toman del response."""
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.status_code = 403
+        mock_response.url = "https://api.test/resource"
+
+        exc = APIError(response=mock_response)
+        self.assertEqual(exc.status_code, 403)
+        self.assertEqual(exc.url, "https://api.test/resource")
+
+    # --- Subclases ---
+
+    def test_validation_error_inherits_parsing(self):
+        """ValidationError hereda correctamente el parseo del nuevo formato."""
+        error_data = {
+            "code": 400,
+            "errors": [{"code": "REQUIRED", "message": "Field is required", "field": "name"}]
+        }
+        exc = ValidationError(errors=error_data)
+        self.assertEqual(exc.message, "Field is required")
+        self.assertEqual(exc.error_items[0].code, "REQUIRED")
+
+    def test_not_found_inherits_parsing(self):
+        """NotFound hereda correctamente el parseo del nuevo formato."""
+        error_data = {
+            "code": 404,
+            "errors": [{"code": "NOT_FOUND", "message": "Resource not found"}]
+        }
+        exc = NotFound(errors=error_data)
+        self.assertEqual(exc.message, "Resource not found")
+        self.assertEqual(exc.error_items[0].code, "NOT_FOUND")
+
+    # --- handle_response_error ---
+
+    def _make_error_response(self, status_code, json_data, url="https://sandbox.alanube.co/dom/v1/test"):
+        """Crea un mock de requests.Response que lance HTTPError en raise_for_status."""
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.status_code = status_code
+        mock_response.json.return_value = json_data
+        mock_response.url = url
+        # Simular raise_for_status: lanza HTTPError si status_code es de error
+        if status_code >= 400:
+            mock_response.raise_for_status.side_effect = requests.HTTPError(response=mock_response)
+        return mock_response
+
+    def test_handle_response_error_400_new_format(self):
+        """handle_response_error lanza ValidationError con el nuevo formato."""
+        mock_response = self._make_error_response(400, {
+            "code": 400,
+            "errors": [{"code": "REQUIRED", "message": "Field is required", "field": "name"}]
+        })
+
+        with self.assertRaises(ValidationError) as ctx:
+            handle_response_error(mock_response)
+        self.assertEqual(ctx.exception.message, "Field is required")
+        self.assertEqual(ctx.exception.error_items[0].code, "REQUIRED")
+        self.assertEqual(ctx.exception.error_items[0].field, "name")
+
+    def test_handle_response_error_404_new_format(self):
+        """handle_response_error lanza NotFound con el nuevo formato."""
+        mock_response = self._make_error_response(404, {
+            "code": 404,
+            "errors": [{"code": "NOT_FOUND", "message": "The requested resource was not found"}]
+        })
+
+        with self.assertRaises(NotFound) as ctx:
+            handle_response_error(mock_response)
+        self.assertEqual(ctx.exception.message, "The requested resource was not found")
+        self.assertEqual(ctx.exception.error_items[0].code, "NOT_FOUND")
+
+    def test_handle_response_error_500_new_format(self):
+        """handle_response_error lanza APIError con el nuevo formato en 500."""
+        mock_response = self._make_error_response(500, {
+            "code": 500,
+            "errors": [{"code": "INTERNAL_ERROR", "message": "Internal server error occurred"}]
+        })
+
+        with self.assertRaises(APIError) as ctx:
+            handle_response_error(mock_response)
+        self.assertEqual(ctx.exception.message, "Internal server error occurred")
+
+    def test_handle_response_error_400_legacy_format(self):
+        """handle_response_error funciona con formato legacy (retrocompatibilidad)."""
+        mock_response = self._make_error_response(400, {
+            "code": 400,
+            "errors": ["legacy error message"]
+        })
+
+        with self.assertRaises(ValidationError) as ctx:
+            handle_response_error(mock_response)
+        self.assertEqual(ctx.exception.message, "legacy error message")
+        self.assertEqual(ctx.exception.error_items[0].code, "UNKNOWN")
+
+    def test_handle_response_error_http_status_code_in_success(self):
+        """Respuesta 200 con httpStatusCode de error lanza APIError."""
+        mock_response = self._make_error_response(200, {
+            "httpStatusCode": 400,
+            "errors": [{"code": "VALIDATION", "message": "Validation error in success response"}]
+        })
+
+        with self.assertRaises(APIError) as ctx:
+            handle_response_error(mock_response)
+        self.assertEqual(ctx.exception.message, "Validation error in success response")
+        self.assertEqual(ctx.exception.error_items[0].code, "VALIDATION")
+
+    # --- APIErrorItem ---
+
+    def test_api_error_item_dataclass(self):
+        """APIErrorItem es un dataclass con los campos correctos."""
+        item = APIErrorItem(code="TEST", message="Test message", field="testField")
+        self.assertEqual(item.code, "TEST")
+        self.assertEqual(item.message, "Test message")
+        self.assertEqual(item.field, "testField")
+
+    def test_api_error_item_default_field_none(self):
+        """field por defecto es None."""
+        item = APIErrorItem(code="TEST", message="Test message")
+        self.assertIsNone(item.field)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alanube"
-version = "1.2.0"
+version = "1.3.0"
 authors = [
   { name = "Wilmer Martinez" },
 ]


### PR DESCRIPTION
Implement `APIErrorItem` dataclass and `_parse_error_response()` to support the new unified error format from the Alanube API: `{"code": 400, "errors": [{"code": "...", "message": "...", "field": "..."}]}`

Legacy formats (`message`, `errors` as lists/strings) are still fully supported. The new format takes precedence when both are present.

Breaking changes to `APIError.errors`:
- Now returns `List[APIErrorItem]` instead of raw `dict`
- New `error_items` attribute as alias for `errors`
- `message` defaults to the first `APIErrorItem.message`
- `messages` property now lists individual error messages

Add 26 unit tests covering parsing, subclasses, edge cases, and full integration with `handle_response_error()`.